### PR TITLE
Refine filters for a NormalizerInGLnZ method

### DIFF
--- a/lib/normalizer.gi
+++ b/lib/normalizer.gi
@@ -7,7 +7,7 @@
 
 InstallMethod( NormalizerInGLnZ, 
     "for PointGroups of space groups from the cryst. groups catalogue",
-    true, [ IsPointGroup ], 0,
+    true, [ IsPointGroup and IsCyclotomicMatrixGroup ], 0,
 function( P )
     local S, p, N, s, gen;
     S := AffineCrystGroupOfPointGroup( P );


### PR DESCRIPTION
This fixes a warning that show up if one starts the upcoming GAP 4.11 with the `-N` command line option, and then loads this package.

For some information on the background of this, see also <https://github.com/gap-system/gap/issues/1649> and <https://github.com/gap-system/gap/issues/2336>