### PR TITLE
change an example from the manual

### DIFF
--- a/doc/crystcat.tex
+++ b/doc/crystcat.tex
@@ -538,26 +538,8 @@ for a matrix group provided by the `MatGroupZClass' function.
 
 \beginexample
 gap> T := CharTableQClass( 4, 20, 3 );;
-gap> Display( T );
-CharTableQClass( 4, 20, 3 )
-
-     2  2  2  1  1  2  2
-     3  1  .  1  1  .  1
-
-       1a 4a 6a 3a 4b 2a
-    2P 1a 2a 3a 3a 2a 1a
-    3P 1a 4b 2a 1a 4a 2a
-    5P 1a 4a 6a 3a 4b 2a
-
-X.1     1  1  1  1  1  1
-X.2     1 -1  1  1 -1  1
-X.3     1  A -1  1 -A -1
-X.4     1 -A -1  1  A -1
-X.5     2  .  1 -1  . -2
-X.6     2  . -1 -1  .  2
-
-A = -E(4)
-  = -Sqrt(-1) = -i
+gap> CharacterDegrees( T );
+[ [ 1, 4 ], [ 2, 2 ] ]
 \endexample
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/doc/make_mantest
+++ b/doc/make_mantest
@@ -5,4 +5,4 @@ echo 'gap> START_TEST( "Crystcat: manual.tst" );'
 awk '/\\beginexample/ {printf "\n";getline; \
    while (! /\\endexample/) { print; getline } }' crystcat.tex
 
-echo 'gap> STOP_TEST( "manual.tst", 10000 );'
+echo 'gap> STOP_TEST( "manual.tst" );'

--- a/tst/manual.tst
+++ b/tst/manual.tst
@@ -82,26 +82,8 @@ gap> CrystCatRecord( P ).parameters;
 
 gap> T := CharTableQClass( 4, 20, 3 );;
 
-gap> Display( T );
-CharTableQClass( 4, 20, 3 )
-
-     2  2  2  1  1  2  2
-     3  1  .  1  1  .  1
-
-       1a 4a 6a 3a 4b 2a
-    2P 1a 2a 3a 3a 2a 1a
-    3P 1a 4b 2a 1a 4a 2a
-    5P 1a 4a 6a 3a 4b 2a
-
-X.1     1  1  1  1  1  1
-X.2     1 -1  1  1 -1  1
-X.3     1  A -1  1 -A -1
-X.4     1 -A -1  1  A -1
-X.5     2  .  1 -1  . -2
-X.6     2  . -1 -1  .  2
-
-A = -E(4)
-  = -Sqrt(-1) = -i
+gap> CharacterDegrees( T );
+[ [ 1, 4 ], [ 2, 2 ] ]
 
 gap> DisplayZClass( 2, 3 );
 #I    Z-class (2,2,1,1) = Z(pm): Bravais type II/I; fully Z-reducible;
@@ -347,4 +329,4 @@ gap> ForAll( RelatorsOfFpGroup( G ), rel -> One(S) =
 >  MappedWord( rel, FreeGeneratorsOfFpGroup(G), GeneratorsOfGroup(S) ) );
 true
 
-gap> STOP_TEST( "manual.tst", 10000 );
+gap> STOP_TEST( "manual.tst" );


### PR DESCRIPTION
Currently the tests are run for the GAP versions from 4.12 to dev. In GAP 4.15, new `Irr` methods (may) become available, which affects the ordering of irreducibles in character tables.

Now we avoid `Display` in manual examples.

(First I tried to get an example in whoch the same `Irr` method is used for the GAP versions in question.
The best such method for supersolvable groups is the Baum-Clausen based one, but this does not store power maps in older GAP versions. For the nonsolvable group A5,
apparently the orderings obtained in GAP 4.12 and GAP 4.15 are also different.)